### PR TITLE
Don't allow self-downgrade if no other admins on team

### DIFF
--- a/app/Http/Controllers/TeamController.php
+++ b/app/Http/Controllers/TeamController.php
@@ -7,6 +7,7 @@ use App\Http\Requests\TeamLeaveRequest;
 use App\Http\Requests\TeamUpdateRequest;
 use App\Models\Team;
 use Illuminate\Http\Request;
+use Spatie\Permission\Models\Role;
 
 class TeamController extends Controller
 {
@@ -20,7 +21,8 @@ class TeamController extends Controller
     public function edit(Request $request)
     {
         return view('team.edit', [
-            'team' => $request->user()->currentTeam
+            'team' => $request->user()->currentTeam->load(['members.roles', 'invites.team']),
+            'roles' => Role::get()
         ]);
     }
 

--- a/app/Policies/TeamPolicy.php
+++ b/app/Policies/TeamPolicy.php
@@ -64,6 +64,12 @@ class TeamPolicy
 
     public function changeMemberRole(User $user, Team $team, User $member)
     {
+        if ($user->id === $member->id) {
+            return $team->members->filter(function ($teamMember) {
+                    return $teamMember->hasRole('team admin');
+                })->count() >= 2;
+        }
+
         if ($team->members->doesntContain($member)) {
             return false;
         }

--- a/resources/views/components/team-member-item.blade.php
+++ b/resources/views/components/team-member-item.blade.php
@@ -57,7 +57,7 @@
                     <x-input-label for="role" value="Role" class="sr-only" />
 
                     <x-select-input class="w-full" name="role" id="role">
-                        @foreach(Role::get() as $role)
+                        @foreach($roles as $role)
                             <option value="{{ $role->name }}" @selected($member->hasRole($role))>{{ $role->name }}</option>
                         @endforeach
                     </x-select-input>

--- a/resources/views/team/partials/team-members.blade.php
+++ b/resources/views/team/partials/team-members.blade.php
@@ -12,7 +12,7 @@
     <div class="mt-6">
         <ul class="divide-y divide-gray-100">
             @foreach($team->members as $member)
-                <x-team-member-item :team="$team" :member="$member" />
+                <x-team-member-item :team="$team" :member="$member" :roles="$roles" />
             @endforeach
         </ul>
 


### PR DESCRIPTION
Added check on policy to only allow downgrade of own user if there is another admin on the team